### PR TITLE
Integrate Keycloack Authentication

### DIFF
--- a/pipelines/batch/src/main/java/org/openmrs/analytics/FetchSearchPageFn.java
+++ b/pipelines/batch/src/main/java/org/openmrs/analytics/FetchSearchPageFn.java
@@ -57,6 +57,20 @@ abstract class FetchSearchPageFn<T> extends DoFn<T, KV<String, Integer>> {
 	
 	private final String sinkPassword;
 	
+	private final Boolean oAuthEnabled;
+	
+	private final String sourceUsername;
+	
+	private final String sourcePassword;
+	
+	private final String clientId;
+	
+	private final String clientSecret;
+	
+	private final String accessTokenUrl;
+	
+	private final String scope;
+	
 	protected final String stageIdentifier;
 	
 	private final String parquetFile;
@@ -83,6 +97,13 @@ abstract class FetchSearchPageFn<T> extends DoFn<T, KV<String, Integer>> {
 		this.sourceUrl = options.getOpenmrsServerUrl() + options.getOpenmrsFhirBaseEndpoint();
 		this.sourceUser = options.getOpenmrsUserName();
 		this.sourcePw = options.getOpenmrsPassword();
+		this.oAuthEnabled = options.isOAuthEnabled();
+		this.sourceUsername = options.getSourceUsername();
+		this.sourcePassword = options.getSourcePassword();
+		this.clientId = options.getSourceClientId();
+		this.clientSecret = options.getSourceClientSecret();
+		this.accessTokenUrl = options.getSourceAccessTokenUrl();
+		this.scope = options.getSourceScope();
 		this.stageIdentifier = stageIdentifier;
 		this.parquetFile = options.getOutputParquetPath();
 		this.secondsToFlush = options.getSecondsToFlushParquetFiles();
@@ -99,7 +120,12 @@ abstract class FetchSearchPageFn<T> extends DoFn<T, KV<String, Integer>> {
 		FhirContext fhirContext = FhirContext.forR4();
 		fhirStoreUtil = FhirStoreUtil.createFhirStoreUtil(sinkPath, sinkUsername, sinkPassword,
 		    fhirContext.getRestfulClientFactory());
-		openmrsUtil = new OpenmrsUtil(sourceUrl, sourceUser, sourcePw, fhirContext);
+		if (oAuthEnabled) {
+			openmrsUtil = new OpenmrsUtil(sourceUrl, sourceUsername, sourcePassword, fhirContext, clientId, clientSecret,
+			        accessTokenUrl, scope, true);
+		} else {
+			openmrsUtil = new OpenmrsUtil(sourceUrl, sourceUser, sourcePw, fhirContext);
+		}
 		fhirSearchUtil = new FhirSearchUtil(openmrsUtil);
 		parquetUtil = new ParquetUtil(parquetFile, secondsToFlush, rowGroupSize, stageIdentifier + "_");
 		parser = fhirContext.newJsonParser();

--- a/pipelines/batch/src/main/java/org/openmrs/analytics/FhirEtl.java
+++ b/pipelines/batch/src/main/java/org/openmrs/analytics/FhirEtl.java
@@ -68,6 +68,11 @@ public class FhirEtl {
 	}
 	
 	static OpenmrsUtil createOpenmrsUtil(FhirEtlOptions options, FhirContext fhirContext) {
+		if (options.isOAuthEnabled()) {
+			return new OpenmrsUtil(options.getOpenmrsServerUrl(), options.getSourceUsername(), options.getSourcePassword(),
+			        fhirContext, options.getSourceClientId(), options.getSourceClientSecret(),
+			        options.getSourceAccessTokenUrl(), options.getSourceScope(), options.isOAuthEnabled());
+		}
 		return new OpenmrsUtil(options.getOpenmrsServerUrl() + options.getOpenmrsFhirBaseEndpoint(),
 		        options.getOpenmrsUserName(), options.getOpenmrsPassword(), fhirContext);
 	}

--- a/pipelines/batch/src/main/java/org/openmrs/analytics/FhirEtlOptions.java
+++ b/pipelines/batch/src/main/java/org/openmrs/analytics/FhirEtlOptions.java
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package org.openmrs.analytics;
 
 import org.apache.beam.sdk.options.Default;
@@ -163,4 +164,49 @@ public interface FhirEtlOptions extends PipelineOptions {
 	String getActivePeriod();
 	
 	void setActivePeriod(String value);
+	
+	/*
+	 * OAuth settings
+	 */
+	@Description("ClientId of the source")
+	@Default.String("")
+	String getSourceClientId();
+	
+	void setSourceClientId(String value);
+	
+	@Description("ClientSecret of the source")
+	@Default.String("")
+	String getSourceClientSecret();
+	
+	void setSourceClientSecret(String value);
+	
+	@Description("Access token url of the source")
+	@Default.String("")
+	String getSourceAccessTokenUrl();
+	
+	void setSourceAccessTokenUrl(String value);
+	
+	@Description("Username of the source")
+	@Default.String("")
+	String getSourceUsername();
+	
+	void setSourceUsername(String value);
+	
+	@Description("Password of the source")
+	@Default.String("")
+	String getSourcePassword();
+	
+	void setSourcePassword(String value);
+	
+	@Description("Scope of the source")
+	@Default.String("profile")
+	String getSourceScope();
+	
+	void setSourceScope(String value);
+	
+	@Description("Flag to switch to OAuth")
+	@Default.Boolean(false)
+	Boolean isOAuthEnabled();
+	
+	void setOAuthEnabled(Boolean value);
 }

--- a/pipelines/batch/src/main/java/org/openmrs/analytics/FhirSearchUtil.java
+++ b/pipelines/batch/src/main/java/org/openmrs/analytics/FhirSearchUtil.java
@@ -45,9 +45,6 @@ public class FhirSearchUtil {
 	
 	FhirSearchUtil(OpenmrsUtil openmrsUtil) {
 		this.openmrsUtil = openmrsUtil;
-		// Check if null
-		System.out.println("----------------------------------------- get access token");
-		// System.out.println(this.openmrsUtil.tokenResponse.getAccessToken());
 	}
 	
 	public Bundle searchByUrl(String searchUrl, int count, SummaryEnum summaryMode) {

--- a/pipelines/batch/src/main/java/org/openmrs/analytics/FhirSearchUtil.java
+++ b/pipelines/batch/src/main/java/org/openmrs/analytics/FhirSearchUtil.java
@@ -45,6 +45,9 @@ public class FhirSearchUtil {
 	
 	FhirSearchUtil(OpenmrsUtil openmrsUtil) {
 		this.openmrsUtil = openmrsUtil;
+		// Check if null
+		System.out.println("----------------------------------------- get access token");
+		// System.out.println(this.openmrsUtil.tokenResponse.getAccessToken());
 	}
 	
 	public Bundle searchByUrl(String searchUrl, int count, SummaryEnum summaryMode) {


### PR DESCRIPTION
The task here is to integrate Keycloack with the openmrs-fhir-analytics pipelines.
See the comment below on how to run it

Getting an issue with how the final variables/objects are getting initialized/persisted
The first time round we are able to get the token fine, but when we hit OpenmrsUtil the second time, we are not passing in the initially created object, which means none of the options are available